### PR TITLE
fix subtitle cutoff

### DIFF
--- a/renderer.c
+++ b/renderer.c
@@ -156,7 +156,7 @@ void prepSubs(char *str){
 
 	// Strip newline and quotes
 	for(int i=0; i<MAX_CHAR; i++){
-		if (*(str+i) != '\n' && *(str+i) != '"') newString[iterator++] = *(str+i);
+		if (*(str+i) != '\n' && *(str+i) != '"' && *(str+i) != '\r') newString[iterator++] = *(str+i);
 	}
 
 	// Determine center offset
@@ -167,7 +167,7 @@ void prepSubs(char *str){
 	// Update string to centered and stripped text
 	for (int i=0; i<MAX_CHAR; i++){
 		*(str+i) = ' ';
-		if (i >= offset && i < offset+length && newString[iterator] != '\r') *(str+i) = newString[iterator++];
+		if (i >= offset && i < offset+length) *(str+i) = newString[iterator++];
 	}
 
 	// Declare the end of our string

--- a/renderer.c
+++ b/renderer.c
@@ -167,7 +167,7 @@ void prepSubs(char *str){
 	// Update string to centered and stripped text
 	for (int i=0; i<MAX_CHAR; i++){
 		*(str+i) = ' ';
-		if (i >= offset-1 && i < offset+length-2) *(str+i) = newString[iterator++];
+		if (i >= offset && i < offset+length && newString[iterator] != '\r') *(str+i) = newString[iterator++];
 	}
 
 	// Declare the end of our string


### PR DESCRIPTION
I fixed a minor bug in `renderer.c` that was causing long single-line subtitles to get cut off. This closes #13.

Here's the behavior before the change:
![image](https://github.com/aidancrowther/ASCIIPlay/assets/71609332/238d0157-0e80-4bfe-93a4-6c1b7348dbfb)

and here's the same subtitle after the change:
![image](https://github.com/aidancrowther/ASCIIPlay/assets/71609332/3c497719-1de0-4544-a8ef-53c886d167c4)

If you accept this PR, please also add the `hacktoberfest-accepted` tag. :)